### PR TITLE
Add tomli 1.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,10 @@ build:
 
 requirements:
   host:
-    # Cannot use flit-core >3.3.0 due to cyclic dependency
+    # Cannot use flit-core >3.3.0 due to cyclic dependency 
     - flit-core 3.3.0
     - pip
-    - python >=3.6
+    - python
   run:
     - python >=3.6
 
@@ -31,12 +31,16 @@ test:
     - pip check
   requires:
     - pip
+    - python <3.10
 
 about:
   home: https://github.com/hukkin/tomli
   summary: A simple TOML parser
   license: MIT
+  license_family: MIT
   license_file: LICENSE
+  dev_url: https://github.com/hukkin/tomli
+  doc_url: https://github.com/hukkin/tomli/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
Bug Tracker: new open issues https://github.com/hukkin/tomli/issues
Upstream license:  License file:  https://github.com/hukkin/tomli/blob/master/LICENSE
Upstream Changelog: https://github.com/hukkin/tomli/blob/master/CHANGELOG.md
Upstream setup file: https://github.com/hukkin/tomli/blob/1.2.2/pyproject.toml

The package tomli is mentioned inside the packages:
pep517 |

Actions:
1. Fix python
2. Add license_family, dev, doc urls

Result:
- all-fail


